### PR TITLE
User search and lock

### DIFF
--- a/src/main/java/com/ncedu/fooddelivery/api/v1/controllers/UserController.java
+++ b/src/main/java/com/ncedu/fooddelivery/api/v1/controllers/UserController.java
@@ -1,9 +1,6 @@
 package com.ncedu.fooddelivery.api.v1.controllers;
 
-import com.ncedu.fooddelivery.api.v1.dto.user.ClientInfoDTO;
-import com.ncedu.fooddelivery.api.v1.dto.user.ModeratorInfoDTO;
-import com.ncedu.fooddelivery.api.v1.dto.user.UserChangeInfoDTO;
-import com.ncedu.fooddelivery.api.v1.dto.user.UserInfoDTO;
+import com.ncedu.fooddelivery.api.v1.dto.user.*;
 import com.ncedu.fooddelivery.api.v1.entities.Role;
 import com.ncedu.fooddelivery.api.v1.entities.User;
 import com.ncedu.fooddelivery.api.v1.errors.notfound.NotFoundEx;
@@ -133,5 +130,15 @@ public class UserController {
     ) {
         List<UserInfoDTO> userList = userService.getAllUsers(pageable);
         return userList;
+    }
+
+    @GetMapping("/api/v1/users/search")
+    @PreAuthorize("hasAnyAuthority('ADMIN', 'MODERATOR')")
+    public List<UserInfoDTO> searchUsers(
+        @Valid @RequestBody UserSearchDTO searchDTO,
+        @PageableDefault(sort = { "rank" }, direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        String phrase = searchDTO.getPhrase();
+        return userService.searchUsers(phrase, pageable);
     }
 }

--- a/src/main/java/com/ncedu/fooddelivery/api/v1/controllers/UserController.java
+++ b/src/main/java/com/ncedu/fooddelivery/api/v1/controllers/UserController.java
@@ -110,11 +110,18 @@ public class UserController {
         return  new ResponseEntity<>(response, HttpStatus.OK);
     }
 
-    @PatchMapping("/api/v1/user/{id}/lock")
+    @PatchMapping("/api/v1/user/{user}/lock")
     @PreAuthorize("hasAnyAuthority('ADMIN', 'MODERATOR')")
-    public UserInfoDTO switchLock(@PathVariable Long id) {
-        return userService.switchLockById(id);
+    public UserInfoDTO lockUser(@PathVariable User user) {
+        return userService.lockById(user);
     }
+
+    @PatchMapping("/api/v1/user/{user}/unlock")
+    @PreAuthorize("hasAnyAuthority('ADMIN', 'MODERATOR')")
+    public UserInfoDTO unlockUser(@PathVariable User user) {
+        return userService.unlockById(user);
+    }
+
 
     @GetMapping("/api/v1/admins")
     @PreAuthorize("hasAuthority('ADMIN')")

--- a/src/main/java/com/ncedu/fooddelivery/api/v1/controllers/UserController.java
+++ b/src/main/java/com/ncedu/fooddelivery/api/v1/controllers/UserController.java
@@ -113,13 +113,13 @@ public class UserController {
     @PatchMapping("/api/v1/user/{user}/lock")
     @PreAuthorize("hasAnyAuthority('ADMIN', 'MODERATOR')")
     public UserInfoDTO lockUser(@PathVariable User user) {
-        return userService.lockById(user);
+        return userService.lockUser(user);
     }
 
     @PatchMapping("/api/v1/user/{user}/unlock")
     @PreAuthorize("hasAnyAuthority('ADMIN', 'MODERATOR')")
     public UserInfoDTO unlockUser(@PathVariable User user) {
-        return userService.unlockById(user);
+        return userService.unlockUser(user);
     }
 
 

--- a/src/main/java/com/ncedu/fooddelivery/api/v1/controllers/UserController.java
+++ b/src/main/java/com/ncedu/fooddelivery/api/v1/controllers/UserController.java
@@ -113,6 +113,12 @@ public class UserController {
         return  new ResponseEntity<>(response, HttpStatus.OK);
     }
 
+    @PatchMapping("/api/v1/user/{id}/lock")
+    @PreAuthorize("hasAnyAuthority('ADMIN', 'MODERATOR')")
+    public UserInfoDTO switchLock(@PathVariable Long id) {
+        return userService.switchLockById(id);
+    }
+
     @GetMapping("/api/v1/admins")
     @PreAuthorize("hasAuthority('ADMIN')")
     public List<UserInfoDTO> getAdminList() {

--- a/src/main/java/com/ncedu/fooddelivery/api/v1/dto/user/UserInfoDTO.java
+++ b/src/main/java/com/ncedu/fooddelivery/api/v1/dto/user/UserInfoDTO.java
@@ -1,11 +1,13 @@
 package com.ncedu.fooddelivery.api.v1.dto.user;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
 
 import java.sql.Timestamp;
 import java.util.UUID;
 
 @Data
+@AllArgsConstructor
 public class UserInfoDTO {
     private Long id;
     private String role;
@@ -13,6 +15,7 @@ public class UserInfoDTO {
     private String email;
     private Timestamp lastSigninDate;
     private UUID avatarId;
+    private Timestamp lockDate;
 
     public UserInfoDTO(Long id, String role, String fullName, String email, Timestamp lastSigninDate, UUID avatarId) {
         this.id = id;

--- a/src/main/java/com/ncedu/fooddelivery/api/v1/dto/user/UserSearchDTO.java
+++ b/src/main/java/com/ncedu/fooddelivery/api/v1/dto/user/UserSearchDTO.java
@@ -1,0 +1,8 @@
+package com.ncedu.fooddelivery.api.v1.dto.user;
+
+import lombok.Data;
+
+@Data
+public class UserSearchDTO {
+    private String phrase;
+}

--- a/src/main/java/com/ncedu/fooddelivery/api/v1/entities/Courier.java
+++ b/src/main/java/com/ncedu/fooddelivery/api/v1/entities/Courier.java
@@ -38,6 +38,7 @@ public class Courier {
     @Column(name = "rating")
     private Float rating;
 
+    @MapsId
     @OneToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "courier_id")
     private User user;

--- a/src/main/java/com/ncedu/fooddelivery/api/v1/entities/User.java
+++ b/src/main/java/com/ncedu/fooddelivery/api/v1/entities/User.java
@@ -65,6 +65,15 @@ public class User implements Serializable, UserDetails {
         this.moderator.setUser(this);
     }
 
+    @OneToOne(cascade=CascadeType.ALL, mappedBy = "user")
+    @PrimaryKeyJoinColumn
+    private Courier courier;
+
+    public void setCourier(Courier courier) {
+        this.courier = courier;
+        this.courier.setUser(this);
+    }
+
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "owner")
     private List<File> files;
 
@@ -82,15 +91,12 @@ public class User implements Serializable, UserDetails {
 
     @Override
     public boolean isAccountNonExpired() {
-        return true;
+        return checkUserNotLocked();
     }
 
     @Override
     public boolean isAccountNonLocked() {
-        if (lockDate == null) {
-            return true;
-        }
-        return false;
+        return checkUserNotLocked();
     }
 
     @Override
@@ -100,9 +106,10 @@ public class User implements Serializable, UserDetails {
 
     @Override
     public boolean isEnabled() {
-        if (lockDate == null) {
-            return true;
-        }
-        return false;
+        return checkUserNotLocked();
+    }
+
+    private boolean checkUserNotLocked() {
+        return lockDate == null ? true : false;
     }
 }

--- a/src/main/java/com/ncedu/fooddelivery/api/v1/repos/UserRepo.java
+++ b/src/main/java/com/ncedu/fooddelivery/api/v1/repos/UserRepo.java
@@ -4,6 +4,7 @@ import com.ncedu.fooddelivery.api.v1.entities.Role;
 import com.ncedu.fooddelivery.api.v1.entities.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 
 import java.util.List;
@@ -12,4 +13,15 @@ public interface UserRepo extends CrudRepository<User, Long> {
     User findByEmail(String email);
     List<User> findByRole(Role role);
     Page<User> findAll(Pageable pageable);
+    @Query(value = "SELECT u.* , ts_rank_cd(us.search_vector, query, 1) AS rank" +
+            " FROM to_tsquery('russian', ?1) AS query, users AS u" +
+            " JOIN users_search AS us" +
+            " ON u.user_id = us.user_search_id" +
+            " WHERE query @@ us.search_vector" +
+            " ORDER BY rank DESC",
+            countQuery = "SELECT count(*)" +
+                    " FROM users_search AS us, to_tsquery('russian', ?1) AS query" +
+                    " WHERE query @@ us.search_vector",
+            nativeQuery = true)
+    Page<User> searchUsers(String search, Pageable pageable);
 }

--- a/src/main/java/com/ncedu/fooddelivery/api/v1/services/UserService.java
+++ b/src/main/java/com/ncedu/fooddelivery/api/v1/services/UserService.java
@@ -25,7 +25,7 @@ public interface UserService {
 
     public void setLastSigninFromNow(User user);
 
-    public UserInfoDTO lockById(User user);
-    public UserInfoDTO unlockById(User user);
+    public UserInfoDTO lockUser(User user);
+    public UserInfoDTO unlockUser(User user);
     public List<UserInfoDTO> searchUsers(String phrase, Pageable pageable);
 }

--- a/src/main/java/com/ncedu/fooddelivery/api/v1/services/UserService.java
+++ b/src/main/java/com/ncedu/fooddelivery/api/v1/services/UserService.java
@@ -26,4 +26,5 @@ public interface UserService {
     public void setLastSigninFromNow(User user);
 
     public UserInfoDTO switchLockById(Long userId);
+    public List<UserInfoDTO> searchUsers(String phrase, Pageable pageable);
 }

--- a/src/main/java/com/ncedu/fooddelivery/api/v1/services/UserService.java
+++ b/src/main/java/com/ncedu/fooddelivery/api/v1/services/UserService.java
@@ -24,4 +24,6 @@ public interface UserService {
 
 
     public void setLastSigninFromNow(User user);
+
+    public UserInfoDTO switchLockById(Long userId);
 }

--- a/src/main/java/com/ncedu/fooddelivery/api/v1/services/UserService.java
+++ b/src/main/java/com/ncedu/fooddelivery/api/v1/services/UserService.java
@@ -25,6 +25,7 @@ public interface UserService {
 
     public void setLastSigninFromNow(User user);
 
-    public UserInfoDTO switchLockById(Long userId);
+    public UserInfoDTO lockById(User user);
+    public UserInfoDTO unlockById(User user);
     public List<UserInfoDTO> searchUsers(String phrase, Pageable pageable);
 }

--- a/src/main/java/com/ncedu/fooddelivery/api/v1/services/impls/UserServiceImpl.java
+++ b/src/main/java/com/ncedu/fooddelivery/api/v1/services/impls/UserServiceImpl.java
@@ -16,6 +16,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -47,7 +48,7 @@ public class UserServiceImpl implements UserService {
     private UserInfoDTO createUserDTO(User user) {
        return new UserInfoDTO(user.getId(), user.getRole().name(),
                 user.getFullName(), user.getEmail(),
-                user.getLastSigninDate(), user.getAvatarId());
+                user.getLastSigninDate(), user.getAvatarId(), user.getLockDate());
     }
 
     @Override
@@ -133,5 +134,21 @@ public class UserServiceImpl implements UserService {
         Timestamp now = new Timestamp(System.currentTimeMillis());
         user.setLastSigninDate(now);
         userRepo.save(user);
+    }
+
+    @Override
+    public UserInfoDTO switchLockById(Long userId) {
+        User user = getUserById(userId);
+        if (Role.isCOURIER(user.getRole().name())) {
+            user.getCourier().setWarehouse(null);
+        }
+        Timestamp lockDate = user.getLockDate();
+        if (lockDate == null) {
+            user.setLockDate(Timestamp.valueOf(LocalDateTime.now()));
+        } else {
+            user.setLockDate(null);
+        }
+        userRepo.save(user);
+        return createUserDTO(user);
     }
 }

--- a/src/main/java/com/ncedu/fooddelivery/api/v1/services/impls/UserServiceImpl.java
+++ b/src/main/java/com/ncedu/fooddelivery/api/v1/services/impls/UserServiceImpl.java
@@ -137,17 +137,22 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public UserInfoDTO switchLockById(Long userId) {
-        User user = getUserById(userId);
-        if (Role.isCOURIER(user.getRole().name())) {
-            user.getCourier().setWarehouse(null);
+    public UserInfoDTO lockById(User user) {
+        if (user.getLockDate() != null) {
+            return createUserDTO(user);
         }
-        Timestamp lockDate = user.getLockDate();
-        if (lockDate == null) {
-            user.setLockDate(Timestamp.valueOf(LocalDateTime.now()));
-        } else {
-            user.setLockDate(null);
+        Timestamp now = Timestamp.valueOf(LocalDateTime.now());
+        user.setLockDate(now);
+        userRepo.save(user);
+        return createUserDTO(user);
+    }
+
+    @Override
+    public UserInfoDTO unlockById(User user) {
+        if (user.getLockDate() == null) {
+            return createUserDTO(user);
         }
+        user.setLockDate(null);
         userRepo.save(user);
         return createUserDTO(user);
     }

--- a/src/main/java/com/ncedu/fooddelivery/api/v1/services/impls/UserServiceImpl.java
+++ b/src/main/java/com/ncedu/fooddelivery/api/v1/services/impls/UserServiceImpl.java
@@ -137,7 +137,7 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public UserInfoDTO lockById(User user) {
+    public UserInfoDTO lockUser(User user) {
         if (user.getLockDate() != null) {
             return createUserDTO(user);
         }
@@ -148,7 +148,7 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public UserInfoDTO unlockById(User user) {
+    public UserInfoDTO unlockUser(User user) {
         if (user.getLockDate() == null) {
             return createUserDTO(user);
         }

--- a/src/main/java/com/ncedu/fooddelivery/api/v1/services/impls/UserServiceImpl.java
+++ b/src/main/java/com/ncedu/fooddelivery/api/v1/services/impls/UserServiceImpl.java
@@ -151,4 +151,27 @@ public class UserServiceImpl implements UserService {
         userRepo.save(user);
         return createUserDTO(user);
     }
+
+    @Override
+    public List<UserInfoDTO> searchUsers(String phrase, Pageable pageable) {
+        String resultPhrase = preparePhraseToSearch(phrase);
+        Iterable<User> users = userRepo.searchUsers(resultPhrase, pageable);
+        Iterator<User> iterator = users.iterator();
+        List<UserInfoDTO> usersDTO = new ArrayList<>();
+        while (iterator.hasNext()) {
+            usersDTO.add(createUserDTO(iterator.next()));
+        }
+        return usersDTO;
+    }
+
+    private String preparePhraseToSearch(String phrase) {
+        String[] splitedPhrase = phrase.split(" ");
+        if (splitedPhrase.length == 1) {
+            return phrase + ":*";
+        }
+        for (int i = 0; i < splitedPhrase.length; i++) {
+            splitedPhrase[i] += ":*";
+        }
+        return String.join(" & ", splitedPhrase);
+    }
 }

--- a/src/main/resources/initDB/data.sql
+++ b/src/main/resources/initDB/data.sql
@@ -108,6 +108,21 @@ BEGIN
     END;
 ' language plpgsql;
 
+/*
+    USERS SEARCH
+*/
+DO ' DECLARE
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM users_search WHERE user_search_id=1) THEN
+        INSERT INTO users_search
+            	SELECT u.user_id, setweight(to_tsvector(''russian'', u.email), ''A'') ||
+            						  setweight(to_tsvector(''russian'', u.full_name), ''B'') ||
+            						  setweight(to_tsvector(''russian'', u.role), ''C'') AS tsv
+            	FROM users AS u;
+
+    END IF;
+END;
+' language plpgsql;
 
     /*
                 CLIENTS

--- a/src/main/resources/initDB/schema.sql
+++ b/src/main/resources/initDB/schema.sql
@@ -47,6 +47,11 @@ CREATE TABLE IF NOT EXISTS users
 	lock_date TIMESTAMP
 );
 
+CREATE TABLE IF NOT EXISTS users_search (
+	user_search_id BIGINT PRIMARY KEY REFERENCES users (user_id) ON DELETE CASCADE,
+	search_vector tsvector
+);
+
 CREATE TABLE IF NOT EXISTS clients
 (
 	client_id BIGINT PRIMARY KEY REFERENCES users (user_id) ON DELETE CASCADE,

--- a/src/main/resources/initDB/schema.sql
+++ b/src/main/resources/initDB/schema.sql
@@ -52,6 +52,50 @@ CREATE TABLE IF NOT EXISTS users_search (
 	search_vector tsvector
 );
 
+/*
+    INSERT TO  USERS_SEARCH if NEW USER ADDED
+*/
+CREATE OR REPLACE FUNCTION copy_users_to_search() RETURNS TRIGGER AS '
+BEGIN
+    INSERT INTO users_search
+        VALUES(new.user_id,
+			   setweight(to_tsvector(''russian'', new.email), ''A'') ||
+			   setweight(to_tsvector(''russian'', new.full_name), ''B'') ||
+			   setweight(to_tsvector(''russian'', new.role::text), ''C''));
+    RETURN new;
+END;
+' language plpgsql;
+
+DROP TRIGGER IF EXISTS copy_users_to_search ON users;
+
+CREATE TRIGGER copy_users_to_search
+	 AFTER INSERT ON users
+     FOR EACH ROW
+     EXECUTE PROCEDURE copy_users_to_search();
+
+/*
+    UPDATE USERS_SEARCH if USER UPDATED
+*/
+CREATE OR REPLACE FUNCTION update_users_in_search() RETURNS TRIGGER AS '
+BEGIN
+    UPDATE users_search
+        SET search_vector =
+			   setweight(to_tsvector(''russian'', new.email), ''A'') ||
+			   setweight(to_tsvector(''russian'', new.full_name), ''B'') ||
+			   setweight(to_tsvector(''russian'', new.role::text), ''C'')
+		WHERE user_search_id = new.user_id;
+    RETURN new;
+END;
+'
+language plpgsql;
+
+DROP TRIGGER IF EXISTS update_users_in_search ON users;
+
+CREATE TRIGGER update_users_in_search
+	 AFTER UPDATE ON users
+     FOR EACH ROW
+     EXECUTE PROCEDURE update_users_in_search();
+
 CREATE TABLE IF NOT EXISTS clients
 (
 	client_id BIGINT PRIMARY KEY REFERENCES users (user_id) ON DELETE CASCADE,

--- a/src/test/java/com/ncedu/fooddelivery/api/v1/services/UserServiceTest.java
+++ b/src/test/java/com/ncedu/fooddelivery/api/v1/services/UserServiceTest.java
@@ -1,0 +1,379 @@
+package com.ncedu.fooddelivery.api.v1.services;
+
+import com.ncedu.fooddelivery.api.v1.dto.user.EmailChangeDTO;
+import com.ncedu.fooddelivery.api.v1.dto.user.PasswordChangeDTO;
+import com.ncedu.fooddelivery.api.v1.dto.user.UserInfoDTO;
+import com.ncedu.fooddelivery.api.v1.entities.Role;
+import com.ncedu.fooddelivery.api.v1.entities.User;
+import com.ncedu.fooddelivery.api.v1.errors.badrequest.AlreadyExistsException;
+import com.ncedu.fooddelivery.api.v1.errors.badrequest.PasswordsMismatchException;
+import com.ncedu.fooddelivery.api.v1.errors.notfound.NotFoundEx;
+import com.ncedu.fooddelivery.api.v1.repos.UserRepo;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+@Slf4j
+public class UserServiceTest {
+
+    @MockBean
+    UserRepo userRepoMock;
+
+    @Autowired
+    UserService userService;
+
+    @Autowired
+    PasswordEncoder passwordEncoder;
+
+    @Test
+    public void getUserByIdSuccess() {
+        Long userId = 1L;
+        User sheldonCooper = UserUtils.adminSheldonCooper(userId);
+
+        when(userRepoMock.findById(userId)).thenReturn(Optional.of(sheldonCooper));
+
+        User result = userService.getUserById(userId);
+        assertEquals(sheldonCooper, result);
+        verify(userRepoMock, times(1)).findById(userId);
+    }
+
+    @Test
+    public void getUserByIdNotFound() {
+        Long userId = 0L;
+        when(userRepoMock.findById(userId)).thenReturn(Optional.empty());
+
+        Exception exception = assertThrows(NotFoundEx.class, () -> {
+            userService.getUserById(userId);
+        });
+        String resultMessage = exception.getMessage();
+        String perfectMessage = new NotFoundEx(userId.toString()).getMessage();
+        assertEquals(perfectMessage, resultMessage);
+        verify(userRepoMock, times(1)).findById(userId);
+    }
+
+    @Test
+    public void getUserDTOByIdSuccess() {
+        Long userId = 1L;
+        User sheldonCooper = UserUtils.adminSheldonCooper(userId);
+
+        when(userRepoMock.findById(userId)).thenReturn(Optional.of(sheldonCooper));
+
+        UserInfoDTO resultDTO = userService.getUserDTOById(userId);
+        UserInfoDTO perfectDTO = UserUtils.createUserDTO(sheldonCooper);
+        assertEquals(perfectDTO, resultDTO);
+        verify(userRepoMock, times(1)).findById(userId);
+    }
+
+    @Test
+    public void getUserDTOByIdNotFound() {
+        Long userId = 0L;
+        when(userRepoMock.findById(userId)).thenReturn(Optional.empty());
+
+        Exception exception = assertThrows(NotFoundEx.class, () -> {
+            userService.getUserDTOById(userId);
+        });
+        String resultMessage = exception.getMessage();
+        String perfectMessage = new NotFoundEx(userId.toString()).getMessage();
+        assertEquals(perfectMessage, resultMessage);
+        verify(userRepoMock, times(1)).findById(userId);
+    }
+
+    @Test
+    public void deleteUserByIdNotFound() {
+        Long userId = 0L;
+        when(userRepoMock.findById(userId)).thenReturn(Optional.empty());
+
+        Exception exception = assertThrows(NotFoundEx.class, () -> {
+            userService.deleteUserById(userId);
+        });
+        String resultMessage = exception.getMessage();
+        String perfectMessage = new NotFoundEx(userId.toString()).getMessage();
+        assertEquals(perfectMessage, resultMessage);
+        verify(userRepoMock, times(1)).findById(userId);
+        verify(userRepoMock, never()).delete(any());
+    }
+
+    @Test
+    public void deleteUserByIdSuccess() {
+        Long userId = 1L;
+        User rajesh = UserUtils.clientRajeshKoothrappali(userId);
+        when(userRepoMock.findById(userId)).thenReturn(Optional.of(rajesh));
+        doNothing().when(userRepoMock).delete(rajesh);
+
+        boolean result = userService.deleteUserById(userId);
+        assertTrue(result);
+        verify(userRepoMock, times(1)).findById(userId);
+        verify(userRepoMock, times(1)).delete(rajesh);
+    }
+
+    @Test
+    public void changeFullNameSuccess() {
+        Long userId = 1L;
+        User penny = UserUtils.clientPennyTeller(userId);
+        String newFullName = "Penny Hofstadter";
+        User pennyWithNewFullName = UserUtils.clientPennyTeller(userId);
+        pennyWithNewFullName.setFullName(newFullName);
+
+        when(userRepoMock.findById(userId)).thenReturn(Optional.of(penny));
+        when(userRepoMock.save(pennyWithNewFullName)).thenReturn(pennyWithNewFullName);
+
+        boolean result = userService.changeFullName(userId, newFullName);
+        assertTrue(result);
+        verify(userRepoMock, times(1)).findById(userId);
+        verify(userRepoMock, times(1)).save(pennyWithNewFullName);
+    }
+
+    @Test
+    public void changeFullNameBad() {
+        Long userId = 1L;
+        User leonard = UserUtils.moderatorLeonardHofstadter(userId);
+
+        when(userRepoMock.findById(userId)).thenReturn(Optional.of(leonard));
+
+        boolean result = userService.changeFullName(userId, null);
+        assertFalse(result);
+        verify(userRepoMock, times(1)).findById(userId);
+        verify(userRepoMock, never()).save(leonard);
+    }
+
+    @Test
+    public void changeEmailSuccess() {
+        Long userId = 1L;
+        User howard = UserUtils.courierHowardWolowitz(userId);
+        String newEmail = "happy-howard@bigbang.theory";
+        User howardWithNewEmail = UserUtils.courierHowardWolowitz(userId);
+        howardWithNewEmail.setEmail(newEmail);
+
+        when(userRepoMock.findByEmail(newEmail)).thenReturn(null);
+        when(userRepoMock.save(howardWithNewEmail)).thenReturn(howardWithNewEmail);
+
+        String password = "password";
+        EmailChangeDTO changeDTO = new EmailChangeDTO();
+        changeDTO.setEmail(newEmail);
+        changeDTO.setPassword(password);
+        boolean result = userService.changeEmail(howard, changeDTO);
+        assertTrue(result);
+        verify(userRepoMock, times(1)).findByEmail(newEmail);
+        verify(userRepoMock, times(1)).save(howardWithNewEmail);
+    }
+
+    @Test
+    public void changeEmailAlreadyExists() {
+        Long userId = 1L;
+        User penny = UserUtils.clientPennyTeller(userId);
+        Long anotherId = 2L;
+        User leonard = UserUtils.moderatorLeonardHofstadter(anotherId);
+
+        String newPennyEmail = leonard.getEmail();
+        when(userRepoMock.findByEmail(newPennyEmail)).thenReturn(leonard);
+
+        String password = "password";
+        EmailChangeDTO changeDTO = new EmailChangeDTO();
+        changeDTO.setEmail(newPennyEmail);
+        changeDTO.setPassword(password);
+
+        Exception exception = assertThrows(AlreadyExistsException.class, () -> {
+           userService.changeEmail(penny, changeDTO);
+        });
+        String resultMessage = exception.getMessage();
+        String perfectMessage = new AlreadyExistsException(newPennyEmail).getMessage();
+        assertEquals(perfectMessage, resultMessage);
+        verify(userRepoMock, times(1)).findByEmail(newPennyEmail);
+        verify(userRepoMock, never()).save(any(User.class));
+    }
+
+    @Test
+    public void changeEmailPasswordMismatch() {
+        Long userId = 1L;
+        User howard = UserUtils.courierHowardWolowitz(userId);
+        String newEmail = "happy-howard@bigbang.theory";
+
+        when(userRepoMock.findByEmail(newEmail)).thenReturn(null);
+
+        String password = "wrong-password";
+        EmailChangeDTO changeDTO = new EmailChangeDTO();
+        changeDTO.setEmail(newEmail);
+        changeDTO.setPassword(password);
+        assertThrows(PasswordsMismatchException.class, ()-> {
+            userService.changeEmail(howard, changeDTO);
+        });
+        verify(userRepoMock, times(1)).findByEmail(newEmail);
+        verify(userRepoMock, never()).save(any(User.class));
+    }
+
+    @Test
+    public void changePasswordSuccess() {
+        Long userId = 1L;
+        User rajesh = UserUtils.clientRajeshKoothrappali(userId);
+        String oldPass = "password";
+        String newPass = "koothrappali";
+        PasswordChangeDTO passwordDTO = new PasswordChangeDTO();
+        passwordDTO.setNewPassword(newPass);
+        passwordDTO.setNewPasswordConfirm(newPass);
+        passwordDTO.setOldPassword(oldPass);
+
+        when(userRepoMock.save(any(User.class))).thenAnswer(invocation -> invocation.getArguments()[0]);
+        boolean result = userService.changePassword(rajesh, passwordDTO);
+
+        assertTrue(result);
+        verify(userRepoMock, times(1)).save(any(User.class));
+    }
+
+    @Test
+    public void changePasswordOldPassIncorrect() {
+        Long userId = 1L;
+        User rajesh = UserUtils.clientRajeshKoothrappali(userId);
+        String oldPass = "wrongOldPass";
+        String newPass = "koothrappali";
+        PasswordChangeDTO passwordDTO = new PasswordChangeDTO();
+        passwordDTO.setNewPassword(newPass);
+        passwordDTO.setNewPasswordConfirm(newPass);
+        passwordDTO.setOldPassword(oldPass);
+
+        Exception exception = assertThrows(PasswordsMismatchException.class, () -> {
+           userService.changePassword(rajesh, passwordDTO);
+        });
+        verify(userRepoMock, never()).save(any(User.class));
+    }
+
+    @Test
+    public void changePasswordNewPassNotSame() {
+        Long userId = 1L;
+        User rajesh = UserUtils.clientRajeshKoothrappali(userId);
+        String oldPass = "password";
+        String newPass = "koothrappali";
+        String newPass2 = "wrongNewPass";
+        PasswordChangeDTO passwordDTO = new PasswordChangeDTO();
+        passwordDTO.setNewPassword(newPass);
+        passwordDTO.setNewPasswordConfirm(newPass2);
+        passwordDTO.setOldPassword(oldPass);
+
+        Exception exception = assertThrows(PasswordsMismatchException.class, () -> {
+            userService.changePassword(rajesh, passwordDTO);
+        });
+        verify(userRepoMock, never()).save(any(User.class));
+    }
+
+    @Test
+    public void getAllAdminsSuccess() {
+        Long userId = 1L;
+        User sheldonAdmin = UserUtils.adminSheldonCooper(userId);
+        List<User> admins = new ArrayList<>();
+        admins.add(sheldonAdmin);
+        when(userRepoMock.findByRole(Role.ADMIN)).thenReturn(admins);
+
+        List<UserInfoDTO> resultDTO = userService.getAllAdmins();
+        List<UserInfoDTO> perfectDTO = new ArrayList<>();
+        perfectDTO.add(UserUtils.createUserDTO(sheldonAdmin));
+        assertEquals(perfectDTO, resultDTO);
+        verify(userRepoMock, times(1)).findByRole(Role.ADMIN);
+    }
+
+    @Test
+    public void getAllUsersSuccess() {
+        User penny = UserUtils.clientPennyTeller(1L);
+        User leonard = UserUtils.moderatorLeonardHofstadter(2L);
+        List<User> users = new ArrayList<>();
+        users.add(penny);
+        users.add(leonard);
+        Page<User> userPage = new PageImpl<>(users);
+        Pageable pageable = PageRequest.of(0, 2);
+        when(userRepoMock.findAll(pageable)).thenReturn(userPage);
+
+        List<UserInfoDTO> resultDTO = userService.getAllUsers(pageable);
+        List<UserInfoDTO> perfectDTO = users.stream()
+                                        .map(user -> UserUtils.createUserDTO(user))
+                                        .collect(Collectors.toList());
+        assertEquals(perfectDTO, resultDTO);
+        verify(userRepoMock, times(1)).findAll(pageable);
+    }
+
+    @Test
+    public void setLastSigninSuccess() {
+        User howard = UserUtils.courierHowardWolowitz(1L);
+        Timestamp current = new Timestamp(System.currentTimeMillis());
+        howard.setLastSigninDate(current);
+        when(userRepoMock.save(any(User.class))).thenAnswer(invocation -> invocation.getArguments()[0]);
+
+        userService.setLastSigninFromNow(howard);
+        assertTrue(current.before(howard.getLastSigninDate()));
+        verify(userRepoMock, times(1)).save(any());
+    }
+
+    @Test
+    public void searchUsersSuccess() {
+        User sheldonCooper = UserUtils.adminSheldonCooper(1L);
+        List<User> users = new ArrayList<>();
+        users.add(sheldonCooper);
+        Page<User> userPage = new PageImpl<>(users);
+        Pageable pageable = PageRequest.of(0, 2);
+        String searchPhrase = "sh co";
+        String resultSearchPhrase = "sh:* & co:*";
+
+        when(userRepoMock.searchUsers(resultSearchPhrase, pageable)).thenReturn(userPage);
+        List<UserInfoDTO> resultDTO = userService.searchUsers(searchPhrase, pageable);
+        List<UserInfoDTO> perfectDTO = new ArrayList<>();
+        perfectDTO.add(UserUtils.createUserDTO(sheldonCooper));
+        assertEquals(perfectDTO, resultDTO);
+        verify(userRepoMock, times(1)).searchUsers(resultSearchPhrase, pageable);
+
+    }
+
+    @Test
+    public void lockUserSuccess() {
+        User penny = UserUtils.clientPennyTeller(1L);
+
+        when(userRepoMock.save(any(User.class))).thenAnswer(invocation -> invocation.getArguments()[0]);
+        UserInfoDTO resultDTO = userService.lockUser(penny);
+        assertTrue(resultDTO.getLockDate() != null);
+        verify(userRepoMock, times(1)).save(any(User.class));
+    }
+
+    @Test
+    public void lockUserAlsoLocked() {
+        User penny = UserUtils.clientPennyTeller(1L);
+        Timestamp current = new Timestamp(System.currentTimeMillis());
+        penny.setLockDate(current);
+
+        UserInfoDTO resultDTO = userService.lockUser(penny);
+        assertEquals(current, resultDTO.getLockDate());
+        verify(userRepoMock, never()).save(any(User.class));
+    }
+
+    @Test
+    public void unlockUserSuccess() {
+        User penny = UserUtils.clientPennyTeller(1L);
+        Timestamp current = new Timestamp(System.currentTimeMillis());
+        penny.setLockDate(current);
+
+        UserInfoDTO resultDTO = userService.unlockUser(penny);
+        assertEquals(null, resultDTO.getLockDate());
+        verify(userRepoMock, times(1)).save(any(User.class));
+    }
+
+    @Test
+    public void unlockUserAlsoUnlocked() {
+        User penny = UserUtils.clientPennyTeller(1L);
+        penny.setLockDate(null);
+        UserInfoDTO resultDTO = userService.unlockUser(penny);
+        assertEquals(null, resultDTO.getLockDate());
+        verify(userRepoMock, never()).save(any(User.class));
+    }
+}

--- a/src/test/java/com/ncedu/fooddelivery/api/v1/services/UserUtils.java
+++ b/src/test/java/com/ncedu/fooddelivery/api/v1/services/UserUtils.java
@@ -1,5 +1,6 @@
 package com.ncedu.fooddelivery.api.v1.services;
 
+import com.ncedu.fooddelivery.api.v1.dto.user.UserInfoDTO;
 import com.ncedu.fooddelivery.api.v1.entities.Role;
 import com.ncedu.fooddelivery.api.v1.entities.User;
 
@@ -45,7 +46,15 @@ public class UserUtils {
         user.setFullName(fullName);
         user.setEmail(email);
         user.setRole(role);
+        //"password" hashed
+        user.setPassword("$2a$08$1h5twwivIL7O9gyjIJ/9eO4I2BeSytSpjsbpaPN.dxWSJM0fuWBBm");
         return user;
+    }
+
+    public static UserInfoDTO createUserDTO(User user) {
+        return new UserInfoDTO(user.getId(), user.getRole().name(),
+                user.getFullName(), user.getEmail(),
+                user.getLastSigninDate(), user.getAvatarId(), user.getLockDate());
     }
 
 }


### PR DESCRIPTION
Доработка сущности User  в части поиска и блокировки/разблокировки + тесты ко всем методам сервиса.
Для поиска добавлена новая таблица users_search в которой хранится ts_vector для каждого пользователя (по которому и производится поиск). Также настроены триеры для обновления и вставки информации в таблицу поиска. Все результаты поиска отсортированы по рангу.

Endpoints:
- _PATCH /api/v1/user/{user}/lock_ (ADMIN, MODERATOR)
Блокирует конкретного пользователя(выставляет врем блокировки lockDate). Если пользователь уже заблокирован ничего не происходит, время блокировки остается прежним.
- _PATCH /api/v1/user/{user}/unlock_ (ADMIN, MODERATOR)
Разблокирует конкретного пользователя(выставляет время блокировки lockDate=null). Если пользователь не блокирован -  ничего не происходит.
- _GET /api/v1/users/search_ (ADMIN, MODERATOR)
Поиск пользователя по заданной фразе (phrase). Поиск производится по ФИО, почте и роли пользователя. Доступна пагинация. 

